### PR TITLE
ポップのレスポンシブ修正

### DIFF
--- a/app/assets/stylesheets/modules/parts/_pop.scss
+++ b/app/assets/stylesheets/modules/parts/_pop.scss
@@ -64,3 +64,25 @@
     }
   }
 }
+
+
+@media screen and (max-width: 1200px) {
+  .containers {
+    &__neumo {
+      &__card {
+        width: 40%;
+        padding: 25px 20px;
+      }
+    }
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .containers {
+    &__neumo {
+      &__card {
+        width: 75%;
+      }
+    }
+  }
+}


### PR DESCRIPTION
# What
ポップのレスポンシブを修正。

# Why
画面を縮小した際に、画面幅が小さく見づらかったため